### PR TITLE
Add option to namespace the metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,13 +18,16 @@ with other plugins. For example, you could use it with
 [`metalsmith-branch`](https://github.com/ericgj/metalsmith-branch) to turn on
 frontmatter parsing for only a subset of files, or you could place it *after*
 [`metalsmith-s3`](https://github.com/mwishek/metalsmith-s3) in the plugin list
-so that it parses frontmatter in downloaded files. Secondly, this plugin
-provides a way to pass options to the underlying frontmatter parsing library,
-[gray-matter](https://github.com/jonschlinkert/gray-matter). This allows you to
-do things like
+so that it parses frontmatter in downloaded files.
+
+Secondly, this plugin provides a way to namespace the frontmatter data under
+a single key (like `page`), and pass options to the underlying frontmatter
+parsing library, [gray-matter](https://github.com/jonschlinkert/gray-matter).
+This allows you to do things like
 [change the delimiter used to separate frontmatter from the rest of the file](https://github.com/jonschlinkert/gray-matter#optionsdelims),
 or
 [set TOML as the default frontmatter format](https://github.com/jonschlinkert/gray-matter#optionslang).
+
 These are all things you can't do with Metalsmith's built-in frontmatter
 parsing.
 
@@ -78,6 +81,39 @@ Metalsmith(__dirname)
 ```
 
 ## Options
+
+### Options.namespace
+
+Type: `string`  
+Default: `undefined`
+
+Namespace all parsed data under a single key.
+
+#### Example
+
+Your frontmatter:
+```` markdown
+---
+title: My title
+author: Joe Writer
+---
+````
+
+In the Javascript:
+```` javascript
+  // either use an options object
+  .use(frontmatter({ namespace: 'page' }))
+  // Or if you use just namespacing, string will suffice
+  .use(frontmatter('page'))
+````
+
+Now, in your HTML, you'll call it like this (example with Handlebars):
+```` html
+  <h1>{{ page.title }}</h1>
+  <p>Author: {{ page.author }}</p>
+````
+
+### Gray Matter Options
 
 metalsmith-matters supports all the options supported by
 [`gray-matter`](https://github.com/jonschlinkert/gray-matter),

--- a/README.md
+++ b/README.md
@@ -101,10 +101,9 @@ author: Joe Writer
 
 In the Javascript:
 ```` javascript
-  // either use an options object
+  // new Metalsmith…
   .use(frontmatter({ namespace: 'page' }))
-  // Or if you use just namespacing, string will suffice
-  .use(frontmatter('page'))
+  // …build()
 ````
 
 Now, in your HTML, you'll call it like this (example with Handlebars):

--- a/lib/index.js
+++ b/lib/index.js
@@ -44,14 +44,10 @@ function extractFrontmatter(file, filePath, options, gm_options){
 /**
  * Metalsmith plugin to extract metadata from frontmatter in file contents.
  *
- * @param {Object|string} options - `Namespace` is used, the rest is passed on to `gray-matter`
+ * @param {Object} options - `Namespace` is used, the rest is passed on to `gray-matter`
  * @return {Function}
  */
 function frontmatter(opts){
-  if (typeof opts === 'string') {
-    opts = { namespace: opts };
-  }
-
   var options = {}, gm_options = {};
   Object.keys(opts || {}).forEach(function(key){
     if (key === 'namespace'){

--- a/lib/index.js
+++ b/lib/index.js
@@ -32,7 +32,8 @@ function extractFrontmatter(file, filePath, options, gm_options){
     }
 
     if (options.hasOwnProperty('namespace')){
-      Object.assign(file, {[options.namespace]: parsed.data});
+      var nsData = {}; nsData[options.namespace] = parsed.data;
+      Object.assign(file, nsData);
     } else {
       Object.assign(file, parsed.data);
     }

--- a/lib/index.js
+++ b/lib/index.js
@@ -12,6 +12,8 @@ if (!Object.assign) Object.assign = require('object-assign');
  *
  * @param {Object} file The Metalsmith file object to extract frontmatter from
  * @param {string} filePath The path to the file represented by `file`
+ * @param {Object} options Options for the extraction routine
+ * @param {Object} gm_options Options for Gray-Matter
  */
 
 function extractFrontmatter(file, filePath, options, gm_options){
@@ -29,10 +31,8 @@ function extractFrontmatter(file, filePath, options, gm_options){
       throw err;
     }
 
-    if (options.hasOwnProperty('group')){
-      var groupedData = {};
-      groupedData[options.group] = parsed.data;
-      Object.assign(file, groupedData);
+    if (options.hasOwnProperty('namespace')){
+      Object.assign(file, {[options.namespace]: parsed.data});
     } else {
       Object.assign(file, parsed.data);
     }
@@ -43,22 +43,20 @@ function extractFrontmatter(file, filePath, options, gm_options){
 /**
  * Metalsmith plugin to extract metadata from frontmatter in file contents.
  *
- * @param {Object} options - Options to pass on to `gray-matter`
+ * @param {Object|string} options - `Namespace` is used, the rest is passed on to `gray-matter`
  * @return {Function}
  */
-
 function frontmatter(opts){
-  // remove implemented options from opts, pass the rest through to Gray Matter
-  var options = {}, gm_options = {};
-  if (typeof opts === 'object'){
-    Object.keys(opts).forEach(function(key){
-      if (key === 'group'){
-        options.group = opts.group;
-      } else {
-        gm_options[key] = opts[key];
-      }
-    });
   }
+
+  var options = {}, gm_options = {};
+  Object.keys(opts || {}).forEach(function(key){
+    if (key === 'namespace'){
+      options[key] = opts[key];
+    } else {
+      gm_options[key] = opts[key];
+    }
+  });
 
   return each(function(file, filePath){
     extractFrontmatter(file, filePath, options, gm_options);

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,8 @@ function extractFrontmatter(file, filePath, options, gm_options){
  * @return {Function}
  */
 function frontmatter(opts){
+  if (typeof opts === 'string') {
+    opts = { namespace: opts };
   }
 
   var options = {}, gm_options = {};

--- a/lib/index.js
+++ b/lib/index.js
@@ -14,12 +14,12 @@ if (!Object.assign) Object.assign = require('object-assign');
  * @param {string} filePath The path to the file represented by `file`
  */
 
-function extractFrontmatter(file, filePath, options){
+function extractFrontmatter(file, filePath, options, gm_options){
   if (utf8(file.contents)) {
     var parsed;
 
     try {
-      parsed = matter(file.contents.toString(), options);
+      parsed = matter(file.contents.toString(), gm_options);
     } catch (e) {
       var errMsg = 'Invalid frontmatter in file';
       if (filePath !== undefined) errMsg += ": " + filePath;
@@ -29,7 +29,13 @@ function extractFrontmatter(file, filePath, options){
       throw err;
     }
 
-    Object.assign(file, parsed.data);
+    if (options.hasOwnProperty('group')){
+      var groupedData = {};
+      groupedData[options.group] = parsed.data;
+      Object.assign(file, groupedData);
+    } else {
+      Object.assign(file, parsed.data);
+    }
     file.contents = new Buffer(parsed.content);
   }
 }
@@ -41,8 +47,20 @@ function extractFrontmatter(file, filePath, options){
  * @return {Function}
  */
 
-function frontmatter(options){
+function frontmatter(opts){
+  // remove implemented options from opts, pass the rest through to Gray Matter
+  var options = {}, gm_options = {};
+  if (typeof opts === 'object'){
+    Object.keys(opts).forEach(function(key){
+      if (key === 'group'){
+        options.group = opts.group;
+      } else {
+        gm_options[key] = opts[key];
+      }
+    });
+  }
+
   return each(function(file, filePath){
-    extractFrontmatter(file, filePath, options);
+    extractFrontmatter(file, filePath, options, gm_options);
   });
 }

--- a/test/fixtures/group-option/src/test.md
+++ b/test/fixtures/group-option/src/test.md
@@ -1,0 +1,6 @@
+---
+someKey: value
+---
+# Header
+
+Content

--- a/test/index.js
+++ b/test/index.js
@@ -26,6 +26,19 @@ describe('metalsmith-matters', function(){
   });
 
   describe('options', function(){
+    describe('implemented', function(){
+      it('should group metadata under one key', function(done){
+        Metalsmith('test/fixtures/group-option')
+          .frontmatter(false)
+          .use(frontmatter({ group: 'groupByKey' }))
+          .build(function(err, files){
+            if (err) return done(err);
+            assert.equal(files["test.md"].groupByKey.someKey, "value");
+            done();
+          });
+      });
+    });
+
     // Given that all metalsmith-matters options are currently implemented by
     // simply passing the options argument to gray-matter, I believe testing
     // only one of gray-matter's options is sufficient coverage of this feature.

--- a/test/index.js
+++ b/test/index.js
@@ -34,6 +34,7 @@ describe('metalsmith-matters', function(){
           .build(function(err, files){
             if (err) return done(err);
             assert.equal(files["test.md"].groupByKey.someKey, "value");
+            assert.equal(files["test.md"].someKey, undefined);
             done();
           });
       });

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,19 @@ describe('metalsmith-matters', function(){
             done();
           });
       });
+
+      it('should namespace metadata if options is a string', function(done){
+        Metalsmith('test/fixtures/group-option')
+          .frontmatter(false)
+          .use(frontmatter('myNamespace'))
+          .build(function(err, files){
+            if (err) return done(err);
+            assert.equal(files["test.md"].myNamespace.someKey, "value");
+            assert.equal(files["test.md"].someKey, undefined);
+            done();
+          });
+      });
+
     });
 
     // Given that all metalsmith-matters options are currently implemented by

--- a/test/index.js
+++ b/test/index.js
@@ -27,13 +27,13 @@ describe('metalsmith-matters', function(){
 
   describe('options', function(){
     describe('implemented', function(){
-      it('should group metadata under one key', function(done){
+      it('should namespace metadata', function(done){
         Metalsmith('test/fixtures/group-option')
           .frontmatter(false)
-          .use(frontmatter({ group: 'groupByKey' }))
+          .use(frontmatter({ namespace: 'myNamespace' }))
           .build(function(err, files){
             if (err) return done(err);
-            assert.equal(files["test.md"].groupByKey.someKey, "value");
+            assert.equal(files["test.md"].myNamespace.someKey, "value");
             assert.equal(files["test.md"].someKey, undefined);
             done();
           });

--- a/test/index.js
+++ b/test/index.js
@@ -38,19 +38,6 @@ describe('metalsmith-matters', function(){
             done();
           });
       });
-
-      it('should namespace metadata if options is a string', function(done){
-        Metalsmith('test/fixtures/group-option')
-          .frontmatter(false)
-          .use(frontmatter('myNamespace'))
-          .build(function(err, files){
-            if (err) return done(err);
-            assert.equal(files["test.md"].myNamespace.someKey, "value");
-            assert.equal(files["test.md"].someKey, undefined);
-            done();
-          });
-      });
-
     });
 
     // Given that all metalsmith-matters options are currently implemented by


### PR DESCRIPTION
For one of my metalsmith installations, I'd like to have all files' metadata grouped under `page.*` (e.g. `page.title`).

This is a quick (and naive) implementation of this functionality to open communication about it. It passes tests, but it introduces first non-gray-matter option, so you might want me to implement it in different way (or add other tests, based on comments in `test/index.js`)
